### PR TITLE
cucumber-features: hooks.feature

### DIFF
--- a/hooks.feature
+++ b/hooks.feature
@@ -1,22 +1,45 @@
-Feature: Hooks
-  Cucumber provides a number of hooks which allow us to run blocks at various
-  points in the Cucumber test cycle. You can put them in your support/env.rb
-  file or any other file under the support directory, for example in a file
-  called support/hooks.rb. There is no association between where the hook is
-  defined and which scenario/step it is run for, but you can use tagged hooks
-  if you want more fine grained control.
+Feature: Environment Hooks
 
-  Scenario: General before hook
-    Given a before hook that causes an error
-    And a step definition matching /^a step passes$/
-    When I run the following feature:
-      """
-        Feature: A before hook runs before every scenario
-          Scenario: The hook runs before this scenario
-            Given a step passes
+  Cucumber provides a number of hooks which allow you to
+  configure the environment for your application. By
+  default hooks are run for each scenario, but you can use
+  tagged hooks if you want more fine grained control.
 
-          Scenario: The hook also runs before this scenario
-            Given a step passes
-      """
-    Then the feature should have 2 failing scenarios
-    And 2 skipped steps
+  Scenario: Before and After
+    Given a passing before hook
+    And a passing after hook
+    When Cucumber executes a scenario
+    Then the before hook is fired before the scenario
+    And the after hook is fired after the scenario
+
+  Scenario: Around
+    Given a passing around hook
+    When Cucumber executes a scenario
+    Then the around hook fires around the scenario
+
+  Scenario: Around fires around other hooks
+    Given a passing around hook
+    And a passing before hook
+    And a passing after hook
+    When Cucumber executes a scenario
+    Then the around hook is fired around the other hooks
+
+  Scenario: Tagged hook with matching scenario tag
+    Given a hook tagged with "@foo"
+    When Cucumber executes a scenario tagged with "@foo"
+    Then the hook is fired
+
+  Scenario: Tagged hook without matching scenario tag
+    Given a hook tagged with "@foo"
+    When Cucumber executes a scenario tagged with "@bar"
+    Then the hook is not fired
+
+  Scenario: Tagged hook with untagged scenario
+    Given a hook tagged with "@foo"
+    When Cucumber executes a scenario with no tags
+    Then the hook is not fired
+
+  Scenario: Untagged hook with tagged scenario
+    Given an untagged hook
+    When Cucumber executes a scenario tagged with "bar"
+    Then the hook is fired


### PR DESCRIPTION
This is my first pass at a hooks.feature. As requested, I am going to be merging it into cucumber-features proper. I did not write scenarios for BeforeStep and AfterStep hooks, because I think those should go the way of the dodo, and be replaced by event listeners on implementation backends. I have a feature for that, too, but it's not done yet. Finally, I'm going to mention @aslakhellesoy, because for some reason or another, he is not set to be notified of pull requests to cucumber-features. Hi Aslak!
