### PR TITLE
Add scenario for pipe as data table contents

### DIFF
--- a/data_tables.feature
+++ b/data_tables.feature
@@ -49,3 +49,19 @@ Feature: Data Tables
         [ "Cucumis anguria", "Burr Gherkin" ]
       ]
       """
+
+  Scenario: data can contain a "|"
+    Given the following data table in a step:
+      """
+      | Latin           | Dutch              |
+      | Cucumis sativus | Komkommer | Augurk |
+      | Cucumis anguria | Burr augurk        |
+      """
+    When the data table is passed to a step mapping that converts it to key/value pairs
+    Then the data table is converted to the following:
+      """
+      [
+        { "Latin":"Cucumis sativus", "Dutch":"Komkommer | Augurk" },
+        { "Latin":"Cucumis anguria", "Dutch":"Burr augurk" }
+      ]
+      """


### PR DESCRIPTION
Look like [SpecFlow allows escapeing pipes](http://stackoverflow.com/questions/12960803/can-i-escape-the-pipe-in-specflow-or-gherkin).

But that seems a bit off. On first glance datatables may look like `|`-delimited, but clearly they are marked up in a fixed width fashion. With `|` and whitespace stripped on conversion.
