### PR TITLE
fixed #current_directory deprected warnings

### DIFF
--- a/step_definitions/cucumber_mappings.rb
+++ b/step_definitions/cucumber_mappings.rb
@@ -50,7 +50,7 @@ EOF
   end
 
   def pattern_exists?(pattern)
-    File.exist?(File.join(current_dir, step_file(pattern)))
+    File.exist?(File.join(expand_path("."), step_file(pattern)))
   end
 
   protected


### PR DESCRIPTION
Works with: 
  gem 'cucumber', "=2.0.0"
  gem 'aruba', "=0.8.0"
  gem 'rspec', "=3.4.0"
and ruby 2.2
